### PR TITLE
fix: Remove PropTypes validation from Video component 

### DIFF
--- a/src/components/Video.js
+++ b/src/components/Video.js
@@ -1,8 +1,3 @@
-import PropTypes from "prop-types";
-
-Video.PropTypes = {
-    src: PropTypes.string.isRequired,
-};
 const Video = ({ src }) => {
     return (
         <video controls width="100%" autoPlay muted>


### PR DESCRIPTION
causing error because of accessing before initialisation and not lint error anymore